### PR TITLE
Post-quantum key support: FVPQ1 locks and the pqKeys ring (TEC-2234)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@fileverse-dev/ddoc": "^2.1.3-patch-26",
         "@fileverse-dev/dsheet": "^4.1.8",
-        "@fileverse/crypto": "^0.0.16",
+        "@fileverse/crypto": "npm:@fileverse/crypto-pqc@0.0.24",
         "@tailwindcss/vite": "^4.0.6",
         "@transcend-io/penumbra": "^5.4.0",
         "fflate": "^0.7.5",
@@ -2127,44 +2127,61 @@
       }
     },
     "node_modules/@fileverse/crypto": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@fileverse/crypto/-/crypto-0.0.16.tgz",
-      "integrity": "sha512-L3u8qAmfvUYeHUNluWScM6FA4wvuBISdQxmPDf+gmnQ6wx/Eh5qM4xpz2kLiZ8PvUd2o7LxhzgqcQlQdknK4sA==",
-      "license": "ISC",
+      "name": "@fileverse/crypto-pqc",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@fileverse/crypto-pqc/-/crypto-pqc-0.0.24.tgz",
+      "integrity": "sha512-9pcrvA7KYGbC7kohgytog1NRd0+4O/k/ZwegOf/KEoFs2kwfpgdRdLJszbMxJUAkucdbjHsJnfkDohqdy9FVBQ==",
+      "license": "AGPL-3.0-only",
       "dependencies": {
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "^1.9.0",
-        "@noble/hashes": "^1.8.0",
-        "@peculiar/webcrypto": "^1.5.0",
+        "@hpke/common": "1.10.1",
+        "@hpke/core": "1.9.0",
+        "@hpke/dhkem-x25519": "1.8.0",
+        "@hpke/hybridkem-x-wing": "0.7.0",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
         "js-base64": "^3.7.7",
+        "mlkem": "2.7.0",
         "tweetnacl": "^1.0.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@fileverse/crypto/node_modules/@noble/ciphers": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.4.0.tgz",
+      "integrity": "sha512-AnjFn0Jv92laAkvMrghlFZq4qQCIN/4DxFV/eooqtC2YTjB7kBeLMS2T9KJX4Dn+ZVXLOwK0lSgqDtx9gvxtiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@fileverse/crypto/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.8.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
-        "node": "^14.21.3 || >=16"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@fileverse/crypto/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
-        "node": "^14.21.3 || >=16"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2283,6 +2300,53 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+    },
+    "node_modules/@hpke/common": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@hpke/common/-/common-1.10.1.tgz",
+      "integrity": "sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@hpke/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@hpke/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@hpke/common": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@hpke/dhkem-x25519": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@hpke/dhkem-x25519/-/dhkem-x25519-1.8.0.tgz",
+      "integrity": "sha512-S1MWWkAfu+TFxySgv5+2P3O4Mx/jk7BsoplzQaA1s3sfUJVJ2UsZsSzSsMc+FXJumLXncoJFlO6mK6mDGspfmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hpke/common": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@hpke/hybridkem-x-wing": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@hpke/hybridkem-x-wing/-/hybridkem-x-wing-0.7.0.tgz",
+      "integrity": "sha512-95M8gJMperA4iWwHFgsEkmxjKcvAX8M4koheFnT85zXcqLL/vBh4597ucw2wLol6d2dC6gpKp9ZApL4d6hmDzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hpke/common": "^1.10.0",
+        "@hpke/dhkem-x25519": "^1.8.0",
+        "mlkem": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -2556,45 +2620,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@peculiar/asn1-schema": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
-      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2",
-        "webcrypto-core": "^1.8.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
       }
     },
     "node_modules/@pkgr/core": {
@@ -6300,20 +6325,6 @@
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
       "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
-    },
-    "node_modules/asn1js": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz",
-      "integrity": "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/assert": {
       "version": "2.1.0",
@@ -10124,6 +10135,15 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mlkem": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mlkem/-/mlkem-2.7.0.tgz",
+      "integrity": "sha512-I2bcB5d6jtkdan6MLGOxObpUbidqv0ej+PhbCGnXUqmcGYZ6X8F0qBpU6HE4mvYc81NSznBrVDp+Uc808Ba2RA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/motion-dom": {
       "version": "11.18.1",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
@@ -11051,24 +11071,6 @@
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pvtsutils": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
-      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/pvutils": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/qs": {
@@ -13028,19 +13030,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz",
       "integrity": "sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA=="
-    },
-    "node_modules/webcrypto-core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
-      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.13",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.7.0"
-      }
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@fileverse-dev/ddoc": "^2.1.3-patch-26",
     "@fileverse-dev/dsheet": "^4.1.8",
-    "@fileverse/crypto": "^0.0.16",
+    "@fileverse/crypto": "npm:@fileverse/crypto-pqc@0.0.24",
     "@tailwindcss/vite": "^4.0.6",
     "@transcend-io/penumbra": "^5.4.0",
     "fflate": "^0.7.5",

--- a/src/components/dsheets-retrieve-section.jsx
+++ b/src/components/dsheets-retrieve-section.jsx
@@ -16,8 +16,7 @@ import {
   reconstructGateMetadata,
   decryptTitleWithFileKey,
 } from '../utils/new-portal-utils'
-import { eciesDecrypt } from '@fileverse/crypto/ecies'
-import { toBytes } from '@fileverse/crypto/utils'
+import { unwrapNewOwnerLockedFileKey } from '../utils/pq-lock'
 import { fromUint8Array } from 'js-base64'
 
 const DsheetsRetrieveSection = () => {
@@ -83,7 +82,8 @@ const DsheetsRetrieveSection = () => {
   useEffect(() => {
     if (
       !portalInformation.legacyOwnerPrivateKey &&
-      !portalInformation.newOwnerPrivateKey
+      !portalInformation.newOwnerPrivateKey &&
+      !(portalInformation.newPortalAddresses?.length > 0)
     ) {
       navigate('/')
     }
@@ -335,10 +335,18 @@ export const DsheetFile = ({
 
       const ownerLockedFileKey = metadata.appLock.lockedFileKey
 
-      const fileKeyArray = eciesDecrypt(
-        toBytes(portalInformation.newOwnerPrivateKey),
-        ownerLockedFileKey
-      )
+      // FVPQ1-prefixed locks (sheets published after the post-quantum
+      // upgrade) route to the portal's PQ key; everything else stays ECIES.
+      const portalKeys =
+        portalInformation.newPortalKeys?.[portalAddress?.toLowerCase()] || {}
+      const fileKeyArray = await unwrapNewOwnerLockedFileKey({
+        lockedFileKey: ownerLockedFileKey,
+        appDecryptionKey:
+          portalKeys.appDecryptionKey || portalInformation.newOwnerPrivateKey,
+        pqKeys: portalKeys.pqKeys,
+        pqDecryptionKey: portalKeys.pqDecryptionKey,
+        keyVersion: metadata.workspaceKeyVersion,
+      })
 
       const fileKey = fromUint8Array(fileKeyArray)
 

--- a/src/components/retrieve-section.jsx
+++ b/src/components/retrieve-section.jsx
@@ -14,9 +14,8 @@ import {
 import { usePortalProvider } from '../providers/portal-provider'
 import { useNavigate, useParams } from 'react-router-dom'
 import { PreviewDdocEditor, handleContentPrint } from '@fileverse-dev/ddoc'
-import { eciesDecrypt } from '@fileverse/crypto/ecies'
-import { toBytes } from '@fileverse/crypto/utils'
 import { fromUint8Array } from 'js-base64'
+import { unwrapNewOwnerLockedFileKey } from '../utils/pq-lock'
 import {
   fetchNewFileResponse,
   decryptNewFile,
@@ -54,7 +53,8 @@ const RetrieveSection = () => {
   useEffect(() => {
     if (
       !portalInformation.legacyOwnerPrivateKey &&
-      !portalInformation.newOwnerPrivateKey
+      !portalInformation.newOwnerPrivateKey &&
+      !(portalInformation.newPortalAddresses?.length > 0)
     ) {
       navigate('/')
     }
@@ -439,10 +439,18 @@ export const NewDdocFile = ({
 
       const ownerLockedFileKey = metadata.ownerLock.lockedFileKey
 
-      const fileKeyArray = eciesDecrypt(
-        toBytes(portalInformation.newOwnerPrivateKey),
-        ownerLockedFileKey
-      )
+      // FVPQ1-prefixed locks (docs published after the post-quantum
+      // upgrade) route to the portal's PQ key; everything else stays ECIES.
+      const portalKeys =
+        portalInformation.newPortalKeys?.[portalAddress?.toLowerCase()] || {}
+      const fileKeyArray = await unwrapNewOwnerLockedFileKey({
+        lockedFileKey: ownerLockedFileKey,
+        appDecryptionKey:
+          portalKeys.appDecryptionKey || portalInformation.newOwnerPrivateKey,
+        pqKeys: portalKeys.pqKeys,
+        pqDecryptionKey: portalKeys.pqDecryptionKey,
+        keyVersion: metadata.workspaceKeyVersion,
+      })
 
       const fileKey = fromUint8Array(fileKeyArray)
 

--- a/src/components/upload-section.jsx
+++ b/src/components/upload-section.jsx
@@ -113,8 +113,9 @@ const UploadSection = () => {
             </button>
           </div>
           <div
-            className={`border-[1px] border-dashed ${dragActive ? 'border-blue-500 bg-blue-50' : 'border-[#E8EBEC]'
-              } 
+            className={`border-[1px] border-dashed ${
+              dragActive ? 'border-blue-500 bg-blue-50' : 'border-[#E8EBEC]'
+            } 
                   rounded font-normal text-sm leading-5 text-[#A1AAB1] p-8 text-center mb-4`}
             onDragEnter={handleDrag}
             onDragLeave={handleDrag}
@@ -198,10 +199,11 @@ const UploadSection = () => {
           </div>
           <button
             className={`p-4 mt-4 w-full rounded font-medium text-[14px] leading-[20px] cursor-pointer
-                  ${file && uploadState === 'uploaded'
-                ? 'bg-[#FFDF0A] text-black hover:bg-[#EFC703]'
-                : 'bg-[#E8EBEC] text-[#A1AAB1]'
-              }`}
+                  ${
+                    file && uploadState === 'uploaded'
+                      ? 'bg-[#FFDF0A] text-black hover:bg-[#EFC703]'
+                      : 'bg-[#E8EBEC] text-[#A1AAB1]'
+                  }`}
             disabled={!file || uploadState !== 'uploaded'}
             onClick={handleRetrieveClick}
           >

--- a/src/hooks/use-upload.jsx
+++ b/src/hooks/use-upload.jsx
@@ -148,6 +148,25 @@ const useUpload = () => {
             ? newBackupKeys[0].source
             : newBackupKeys?.source)
 
+        // Per-portal key material for the retrieve pages. Upgraded and born
+        // post-quantum portals carry their key ring (pqKeys); the flat
+        // pqDecryptionKey of the very first PQ backup format is kept as a
+        // fallback candidate (see utils/pq-lock.js). Nothing is derived.
+        const newBackupKeysList = Array.isArray(newBackupKeys)
+          ? newBackupKeys
+          : newBackupKeys && Object.keys(newBackupKeys).length > 0
+            ? [newBackupKeys]
+            : []
+        const newPortalKeys = {}
+        for (const k of newBackupKeysList) {
+          if (k?.portalAddress) {
+            newPortalKeys[k.portalAddress.toLowerCase()] = {
+              appDecryptionKey: k.appDecryptionKey || '',
+              pqKeys: Array.isArray(k.pqKeys) ? k.pqKeys : [],
+              pqDecryptionKey: k.pqDecryptionKey || '',
+            }
+          }
+        }
         setPortalInformation({
           legacyFileCount,
           newFileCount,
@@ -155,6 +174,7 @@ const useUpload = () => {
           legacyOwnerPrivateKey: legacyOwnerPrivateKey,
           newPortalAddresses: newPortalAddresses || [],
           newOwnerPrivateKey: firstNewBackupKey?.appDecryptionKey || '',
+          newPortalKeys,
           source: source || '',
         })
         setUploadState('uploaded')

--- a/src/providers/portal-provider.jsx
+++ b/src/providers/portal-provider.jsx
@@ -9,6 +9,7 @@ const PortalProviderContext = createContext({
     legacyOwnerPrivateKey: '',
     newPortalAddresses: [],
     newOwnerPrivateKey: '',
+    newPortalKeys: {},
     source: '',
   },
 })
@@ -23,6 +24,7 @@ const PortalProvider = ({ children }) => {
     legacyOwnerPrivateKey: '',
     newPortalAddresses: [],
     newOwnerPrivateKey: '',
+    newPortalKeys: {},
     source: '',
   })
   return (

--- a/src/utils/contract-functions.js
+++ b/src/utils/contract-functions.js
@@ -61,3 +61,14 @@ export const getNewPortalKeysVerifiers = async (contractAddress) => {
     args: [0],
   })
 }
+
+// Post-quantum ring entries live at their own verifier index (the entry's
+// `version`); an upgraded portal keeps its EC pair at 0.
+export const getNewPortalKeysVerifiersAt = async (contractAddress, version) => {
+  return await publicClient.readContract({
+    address: contractAddress,
+    abi: newAbi,
+    functionName: 'keyVerifiers',
+    args: [version],
+  })
+}

--- a/src/utils/get-portal-keys.js
+++ b/src/utils/get-portal-keys.js
@@ -23,16 +23,38 @@ function isNewBackupKeysFormat(value) {
   )
 }
 
+// A post-quantum ring: one entry per portal key version, private key inside.
+export function hasPqRing(value) {
+  return (
+    Array.isArray(value?.pqKeys) &&
+    value.pqKeys.length > 0 &&
+    value.pqKeys.every(
+      (k) =>
+        k &&
+        typeof k.publicKey === 'string' &&
+        typeof k.privateKey === 'string' &&
+        Number.isInteger(k.version)
+    )
+  )
+}
+
+export function hasEcPair(value) {
+  return Boolean(value?.appEncryptionKey && value?.appDecryptionKey)
+}
+
 function isNewBackupKeys(value) {
   return (
     typeof value === 'object' &&
     'portalAddress' in value &&
     'ownerDid' in value &&
     'ownerSecret' in value &&
-    'appEncryptionKey' in value &&
-    'appDecryptionKey' in value &&
-    'permissionAddress' in value &&
-    'source' in value
+    // permissionAddress is optional: ddocs only writes it when the portal has
+    // a permission contract, and portals created after the semaphore cleanup
+    // (ddocs #1100) never deploy one. validateNewKey does not require it.
+    'source' in value &&
+    // Upgraded portals carry both; born post-quantum portals carry only the
+    // ring; classic portals only the EC pair.
+    (hasEcPair(value) || hasPqRing(value))
   )
 }
 

--- a/src/utils/pq-lock.js
+++ b/src/utils/pq-lock.js
@@ -1,0 +1,72 @@
+import { pqDecrypt, VERSION as PQ_VERSION } from '@fileverse/crypto/pq'
+import { eciesDecrypt } from '@fileverse/crypto/ecies'
+import { toBytes } from '@fileverse/crypto/utils'
+
+// Mirror of the dDocs app's doc-lock read router (keystore/new-crypto.ts):
+// a lock wrapped with the portal's post-quantum pair announces itself with
+// the FVPQ1 prefix; legacy ECIES strings are 4 __n__-joined base64 parts
+// and can never start with it.
+export const isPqLock = (encrypted) =>
+  typeof encrypted === 'string' && encrypted.startsWith(PQ_VERSION)
+
+export const MISSING_PQ_KEYS_MESSAGE =
+  'This document is protected with post-quantum keys that are not in this backup file. Download a fresh backup from dDocs Settings and try again.'
+
+/**
+ * Candidate post-quantum private keys for a portal, most likely first.
+ *
+ * A backup file carries the portal's key ring as `pqKeys`: one entry per
+ * version, each with the 32-byte private key. Writes stamp the version of
+ * the entry that sealed them (metadata.workspaceKeyVersion), so that entry
+ * is tried first, then the rest newest-first. The flat `pqDecryptionKey`
+ * of the very first backup format is kept as a last candidate.
+ *
+ * The pair is random and stored, never derived: a backup without it cannot
+ * open post-quantum locks, full stop.
+ */
+const pqKeyCandidates = ({ pqKeys, pqDecryptionKey, keyVersion }) => {
+  const ring = Array.isArray(pqKeys)
+    ? pqKeys.filter((k) => k && typeof k.privateKey === 'string')
+    : []
+  const byVersion = [...ring].sort((a, b) => b.version - a.version)
+  const preferred =
+    keyVersion !== undefined && keyVersion !== null
+      ? byVersion.filter((k) => k.version === keyVersion)
+      : []
+  const rest = byVersion.filter((k) => !preferred.includes(k))
+  const candidates = [...preferred, ...rest].map((k) => k.privateKey)
+  if (pqDecryptionKey) candidates.push(pqDecryptionKey)
+  return candidates
+}
+
+/**
+ * Unwrap a new-portal ownerLock/appLock fileKey with whichever key
+ * generation the lock was written for. Returns the raw fileKey bytes.
+ */
+export const unwrapNewOwnerLockedFileKey = async ({
+  lockedFileKey,
+  appDecryptionKey,
+  pqKeys,
+  pqDecryptionKey,
+  keyVersion,
+}) => {
+  if (isPqLock(lockedFileKey)) {
+    const candidates = pqKeyCandidates({ pqKeys, pqDecryptionKey, keyVersion })
+    if (candidates.length === 0) throw new Error(MISSING_PQ_KEYS_MESSAGE)
+    let lastError
+    for (const candidate of candidates) {
+      try {
+        return await pqDecrypt(toBytes(candidate), lockedFileKey)
+      } catch (err) {
+        lastError = err
+      }
+    }
+    throw lastError || new Error(MISSING_PQ_KEYS_MESSAGE)
+  }
+  if (!appDecryptionKey) {
+    throw new Error(
+      'This document uses the portal EC key, which is not in this backup file.'
+    )
+  }
+  return eciesDecrypt(toBytes(appDecryptionKey), lockedFileKey)
+}

--- a/src/utils/validate-keys.js
+++ b/src/utils/validate-keys.js
@@ -3,6 +3,7 @@ import {
   PROD_DDOC_DOMAIN,
   PROD_DSHEETS_DOMAIN,
 } from './constants'
+import { hasEcPair, hasPqRing } from './get-portal-keys'
 
 export const keysInLegacySecretFile = [
   'portalAddress',
@@ -15,12 +16,9 @@ export const keysInLegacySecretFile = [
   'source',
 ]
 
-export const keysInNewSecretFile = [
-  'portalAddress',
-  'appEncryptionKey',
-  'appDecryptionKey',
-  'source',
-]
+// Plus an EC pair (appEncryptionKey + appDecryptionKey) and/or a
+// post-quantum ring (pqKeys), checked separately below.
+export const keysInNewSecretFile = ['portalAddress', 'source']
 
 export class InvalidRecoveryJsonError extends Error {
   constructor(message) {
@@ -67,6 +65,9 @@ export const validateNewKey = (keysObject) => {
       throw new InvalidRecoveryJsonError('Recovery file is missing keys')
     }
   })
+  if (!hasEcPair(keysObject) && !hasPqRing(keysObject)) {
+    throw new InvalidRecoveryJsonError('Recovery file is missing keys')
+  }
 }
 
 export const validateKey = (legacyKeysObject, newKeysArray) => {

--- a/src/utils/verify-keys.js
+++ b/src/utils/verify-keys.js
@@ -1,7 +1,9 @@
 import {
   verifyPortalKeysFromContract,
   verifyNewPortalKeysFromContract,
+  verifyPqRingFromContract,
 } from './verify-portal-keys-from-contract'
+import { hasEcPair, hasPqRing } from './get-portal-keys'
 
 export const verifyLegacyKeys = async (oldBackupKeys) => {
   const {
@@ -31,13 +33,25 @@ export const verifyLegacyKeys = async (oldBackupKeys) => {
 }
 
 export const verifyNewKeys = async (newBackupKeys) => {
-  const { portalAddress, appEncryptionKey, appDecryptionKey } = newBackupKeys
+  const { portalAddress, appEncryptionKey, appDecryptionKey, pqKeys } =
+    newBackupKeys
 
-  const isVerified = await verifyNewPortalKeysFromContract({
-    appEncryptionKey,
-    appDecryptionKey,
-    contractAddress: portalAddress,
-  })
+  // Whatever the file carries has to match the portal: the EC pair at
+  // verifier 0, each post-quantum ring entry at its version.
+  let isVerified = true
+  if (hasEcPair(newBackupKeys)) {
+    isVerified = await verifyNewPortalKeysFromContract({
+      appEncryptionKey,
+      appDecryptionKey,
+      contractAddress: portalAddress,
+    })
+  }
+  if (isVerified && hasPqRing(newBackupKeys)) {
+    isVerified = await verifyPqRingFromContract({
+      pqKeys,
+      contractAddress: portalAddress,
+    })
+  }
   return {
     portalAddress,
     newKeysVerified: isVerified,

--- a/src/utils/verify-portal-keys-from-contract.js
+++ b/src/utils/verify-portal-keys-from-contract.js
@@ -2,6 +2,7 @@ import { isKeysVerified, isNewKeysVerified } from './is-keys-verified'
 import {
   getPortalKeysVerifiers,
   getNewPortalKeysVerifiers,
+  getNewPortalKeysVerifiersAt,
 } from './contract-functions'
 
 export const EMPTY_HASH =
@@ -26,4 +27,22 @@ export const verifyNewPortalKeysFromContract = async ({
 }) => {
   const keyVerifiers = await getNewPortalKeysVerifiers(contractAddress)
   return isNewKeysVerified(appEncryptionKey, appDecryptionKey, keyVerifiers)
+}
+
+// Every ring entry must be registered on the portal at its own version:
+// sha256(publicKey) / sha256(privateKey), same as the EC pair at 0.
+export const verifyPqRingFromContract = async ({ pqKeys, contractAddress }) => {
+  for (const entry of pqKeys) {
+    const keyVerifiers = await getNewPortalKeysVerifiersAt(
+      contractAddress,
+      entry.version
+    )
+    const ok = await isNewKeysVerified(
+      entry.publicKey,
+      entry.privateKey,
+      keyVerifiers
+    )
+    if (!ok) return false
+  }
+  return true
 }


### PR DESCRIPTION
Promotes staging to main. One change since #18: PR #17 (post-quantum backup support).

- Reads FVPQ1 locks with the pqKeys ring from the new backup format; classic ECIES backups unchanged.
- Accepts backups without permissionAddress (ddocs stopped writing it for portals created after the semaphore cleanup, #1100, which is already on ddocs prod).
- Includes the gz1 dsheet content inflate from #18.

Verified on the PR preview with a real upgraded-account backup (portal 0xdcda2b…): byte-matched against the chain ring and accepted by the uploader.